### PR TITLE
fix: typo in email template

### DIFF
--- a/app/api/authentication/templates/authentication/new_registration_email.html
+++ b/app/api/authentication/templates/authentication/new_registration_email.html
@@ -16,7 +16,7 @@
         </div>
         {% endfor %}
         
-        <p>You can login to {{ request.scheme }}:/{{ request.get_host }}{% url 'admin:index' %} to check it out.</p>
+        <p>You can login to {{ request.scheme }}://{{ request.get_host }}{% url 'admin:index' %} to check it out.</p>
         <br/>
         <br/>
         Best Regards, <br/>


### PR DESCRIPTION
It was breaking the URL and defaulting to HTTP, which doesn't work yet on backend server

![image](https://user-images.githubusercontent.com/13855909/98071691-3943d900-1e8a-11eb-94f1-d4861128c73a.png)
