### PR TITLE
fix (ci): remove Django Test action on PR

### DIFF
--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -6,8 +6,6 @@ name: Django Test
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Github secrets are not passed to external PRs from forks, so tests
always fail