### PR TITLE
fix: token expiry after 14 days (closes #92)

### DIFF
--- a/app/api/authentication/models.py
+++ b/app/api/authentication/models.py
@@ -89,7 +89,7 @@ class ExpiringToken(Token):
         expiry_interval = settings.TOKEN_SETTINGS.get(
             "EXPIRING_TOKEN_LIFESPAN", timedelta(days=30)
         )
-        if self.created < now - expiry_interval:
+        if self.refreshed < now - expiry_interval:
             return True
         return False
 

--- a/app/api/authentication/services.py
+++ b/app/api/authentication/services.py
@@ -225,7 +225,7 @@ def read_profile(user=None, email=None):
     try:
         profile = get_profile(user=user, email=email)
     except (AppUser.DoesNotExist, Profile.DoesNotExist):
-        return ProfileDoesNotExist(email=email), status.HTTP_404_NOT_FOUND
+        return ProfileDoesNotExist(email=email).to_dict(), status.HTTP_404_NOT_FOUND
 
     serializer = ProfileReadUpdateSerializer(profile)
     response = {"type": "success", "profile": serializer.data}

--- a/app/api/authentication/services.py
+++ b/app/api/authentication/services.py
@@ -4,22 +4,18 @@ from django.conf import settings
 from django.core.files import File
 from django.core.mail import mail_managers
 from django.template.loader import render_to_string
-from response.errors.authentication import (
-    AccountNotApproved,
-    ProfileDoesNotExist,
-    UserNotRegistered,
-    InvalidAppleUser,
-)
+from response.errors.authentication import (AccountNotApproved,
+                                            InvalidAppleUser,
+                                            ProfileDoesNotExist,
+                                            UserNotRegistered)
 from rest_framework import exceptions, status
 
 from authentication.authentication import AppleOauth, GoogleOauth, WeChatOauth
-from authentication.models import AppUser, ExpiringToken, Profile, AppleUser
-from authentication.serializers import (
-    LoginSerializer,
-    ProfileCreateSerializer,
-    ProfileReadUpdateSerializer,
-    RegistrationStatusSerializer,
-)
+from authentication.models import AppleUser, AppUser, ExpiringToken, Profile
+from authentication.serializers import (LoginSerializer,
+                                        ProfileCreateSerializer,
+                                        ProfileReadUpdateSerializer,
+                                        RegistrationStatusSerializer)
 
 
 def register_user(request):

--- a/app/api/authentication/services.py
+++ b/app/api/authentication/services.py
@@ -4,18 +4,22 @@ from django.conf import settings
 from django.core.files import File
 from django.core.mail import mail_managers
 from django.template.loader import render_to_string
-from response.errors.authentication import (AccountNotApproved,
-                                            InvalidAppleUser,
-                                            ProfileDoesNotExist,
-                                            UserNotRegistered)
 from rest_framework import exceptions, status
 
 from authentication.authentication import AppleOauth, GoogleOauth, WeChatOauth
 from authentication.models import AppleUser, AppUser, ExpiringToken, Profile
-from authentication.serializers import (LoginSerializer,
-                                        ProfileCreateSerializer,
-                                        ProfileReadUpdateSerializer,
-                                        RegistrationStatusSerializer)
+from authentication.serializers import (
+    LoginSerializer,
+    ProfileCreateSerializer,
+    ProfileReadUpdateSerializer,
+    RegistrationStatusSerializer,
+)
+from response.errors.authentication import (
+    AccountNotApproved,
+    InvalidAppleUser,
+    ProfileDoesNotExist,
+    UserNotRegistered,
+)
 
 
 def register_user(request):


### PR DESCRIPTION
**Issue**
The token of users are deleted after 14 days irrespective of whether they are continually using the app or not. The expected behavior is to delete tokens only if the user has been continuously inactive for 14 days.
**Fix**
Compare refreshed time to present instead of token creation time
