### PR TITLE
Revert "chore(deps): bump rsa from 4.0 to 4.1 in /app"

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -35,7 +35,7 @@ pytz==2019.3
 PyYAML==5.3
 requests==2.23.0
 rope==0.16.0
-rsa==4.1
+rsa==4.0
 s3transfer==0.3.3
 six==1.14.0
 sqlparse==0.3.0


### PR DESCRIPTION
Reverts melton-foundation/Melton-App-Server#100
Dependency versions don't match. Has to be checked manually and then done