### PR TITLE
hotfix: temporarily disable sidebar (refs #116)

### DIFF
--- a/app/api/authentication/admin.py
+++ b/app/api/authentication/admin.py
@@ -105,3 +105,5 @@ admin.site.register(ExpiringToken, TokenAdmin)
 admin.site.register(AppUser, AppUserAdmin)
 admin.site.register(Profile, ProfileAdmin)
 admin.site.register(SustainableDevelopmentGoal)
+
+admin.site.enable_nav_sidebar = False


### PR DESCRIPTION
This PR refers #116 
Until the static files issue is fixed, this is a hotfix to disable the new feature from Django 3.1
With this change, the admin dashboard will look same as previous versions of django and sidebar wont be shown.