### PR TITLE
chore: remove mypy linter in github workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,3 +30,4 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false


### PR DESCRIPTION
Remove mypy linter since there are no type annotations used in codebase